### PR TITLE
Better Negative Matching Messages

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -35,6 +35,15 @@ final class Assert
         }
     }
 
+    public static function assertCallback(callable $callback, $actual, $message='')
+    {
+        return self::assertThat(
+            Matchers::callback($callback),
+            $actual,
+            $message
+        );
+    }
+
     public static function assertContains($expected, $actual, $message='')
     {
         return self::assertThat(

--- a/src/Matcher/Anything.php
+++ b/src/Matcher/Anything.php
@@ -22,13 +22,14 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 
 /**
  * Matches any value.
  *
  * @since   1.0
  */
-class Anything implements Matcher
+class Anything implements Matcher, Negative
 {
     /**
      * {@inheritdoc}
@@ -44,5 +45,13 @@ class Anything implements Matcher
     public function __toString()
     {
         return 'is anything';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negativeMessage()
+    {
+        return 'is nothing';
     }
 }

--- a/src/Matcher/Callback.php
+++ b/src/Matcher/Callback.php
@@ -22,13 +22,14 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 
 /**
  * Run a value through a callback.
  *
  * @since   1.0
  */
-class Callback implements Matcher
+class Callback implements Matcher, Negative
 {
     /**
      * The callback that the value is to be run through
@@ -63,6 +64,14 @@ class Callback implements Matcher
      */
     public function __toString()
     {
-        return 'is a value matching a user defined callback';
+        return 'matches user defined callback';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negativeMessage()
+    {
+        return 'does not match a user defined callback';
     }
 }

--- a/src/Matcher/Contains.php
+++ b/src/Matcher/Contains.php
@@ -22,6 +22,7 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 use Counterpart\Exception\InvalidArgumentException;
 
 /**
@@ -30,7 +31,7 @@ use Counterpart\Exception\InvalidArgumentException;
  *
  * @since   1.0
  */
-class Contains implements Matcher
+class Contains implements Matcher, Negative
 {
     /**
      * The value to search for.
@@ -84,6 +85,19 @@ class Contains implements Matcher
      */
     public function __toString()
     {
-        return 'is an array or Traversable containing ' . \Counterpart\prettify($this->expected);
+        return 'is an array or Traversable containing '.$this->prettyExpected();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negativeMessage()
+    {
+        return 'is an array or Traversable that does not contain '.$this->prettyExpected();
+    }
+
+    private function prettyExpected()
+    {
+        return \Counterpart\prettify($this->expected);
     }
 }

--- a/src/Matcher/HasKey.php
+++ b/src/Matcher/HasKey.php
@@ -29,7 +29,7 @@ use Counterpart\Negative;
  *
  * @since   1.0
  */
-class HasKey implements Matcher
+class HasKey implements Matcher, Negative
 {
     /**
      * the key to check for.

--- a/src/Matcher/HasKey.php
+++ b/src/Matcher/HasKey.php
@@ -22,6 +22,7 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 
 /**
  * Checks to see if an array (or ArrayAccess implementation) has a given key.
@@ -73,6 +74,19 @@ class HasKey implements Matcher
      */
     public function __toString()
     {
-        return "is an array or ArrayAccess implementation with the key " . \Counterpart\prettify($this->key);
+        return 'is an array or ArrayAccess with the key '.$this->prettyKey();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negativeMessage()
+    {
+        return 'is an array or ArrayAccess without the key '.$this->prettyKey();
+    }
+
+    private function prettyKey()
+    {
+        return \Counterpart\prettify($this->key);
     }
 }

--- a/src/Matcher/HasProperty.php
+++ b/src/Matcher/HasProperty.php
@@ -30,7 +30,7 @@ use Counterpart\Exception\InvalidArgumentException;
  *
  * @since   1.0
  */
-class HasProperty implements Matcher
+class HasProperty implements Matcher, Negative
 {
     /**
      * the property to check for.

--- a/src/Matcher/HasProperty.php
+++ b/src/Matcher/HasProperty.php
@@ -22,6 +22,7 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 use Counterpart\Exception\InvalidArgumentException;
 
 /**
@@ -84,5 +85,13 @@ class HasProperty implements Matcher
     public function __toString()
     {
         return "is an object with the property {$this->propertyName}";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negativeMessage()
+    {
+        return "is an object without the property {$this->propertyName}";
     }
 }

--- a/src/Matcher/LogicalNot.php
+++ b/src/Matcher/LogicalNot.php
@@ -22,6 +22,7 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 
 /**
  * Test a matcher and negates it.
@@ -72,6 +73,10 @@ class LogicalNot implements Matcher
      */
     public function __toString()
     {
+        if ($this->matcher instanceof Negative) {
+            return $this->matcher->negativeMessage();
+        }
+
         return preg_replace('/(\b)is(\b)/', '$1is not$2', (string)$this->matcher);
     }
 }

--- a/src/Matcher/MatchesRegex.php
+++ b/src/Matcher/MatchesRegex.php
@@ -22,6 +22,7 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 use Counterpart\Exception\InvalidArgumentException;
 
 /**
@@ -30,7 +31,7 @@ use Counterpart\Exception\InvalidArgumentException;
  *
  * @since   1.0
  */
-class MatchesRegex implements Matcher
+class MatchesRegex implements Matcher, Negative
 {
     /**
      * The regex pattern to match agains.
@@ -80,7 +81,15 @@ class MatchesRegex implements Matcher
      */
     public function __toString()
     {
-        return "is a value matching the regular expression {$this->regexPattern}";
+        return "matches the regular expression {$this->regexPattern}";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negativeMessage()
+    {
+        return "does not match the regular expression {$this->regexPattern}";
     }
 
     private function isStringyObject($value)

--- a/src/Matcher/StringContains.php
+++ b/src/Matcher/StringContains.php
@@ -22,6 +22,7 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Negative;
 use Counterpart\Exception\InvalidArgumentException;
 
 /**
@@ -29,7 +30,7 @@ use Counterpart\Exception\InvalidArgumentException;
  *
  * @since   1.0
  */
-class StringContains implements Matcher
+class StringContains implements Matcher, Negative
 {
     /**
      * The string to search for.
@@ -90,6 +91,14 @@ class StringContains implements Matcher
      */
     public function __toString()
     {
-        return "is a string containing {$this->needle}";
+        return "is a string containing \"{$this->needle}\"";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function negativeMessage()
+    {
+        return "is a string that does not contain \"{$this->needle}\"";
     }
 }

--- a/src/Negative.php
+++ b/src/Negative.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright 2014 Christopher Davis <http://christopherdavis.me>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package     Counterpart
+ * @copyright   2014 Christopher Davis <http://christopherdavis.me>
+ * @license     http://opensource.org/licenses/apache-2.0 Apache-2.0
+ */
+
+namespace Counterpart;
+
+/**
+ * Marks a matcher as being aware that it may be used within a `LogicalNot`. When
+ * `LogicalNot::__toString` is called, the `negativeMessage` will be called to
+ * describe the failure.
+ *
+ * @since    1.3
+ */
+interface Negative
+{
+    /**
+     * Describe the opposive of the match. If the matcher's `__toString` method
+     * returned something 'is equal to "SomeValue"' then `negativeMessage` might
+     * return something like 'is not equal to "SomeValue"'.
+     *
+     * @since   1.3
+     * @return  string
+     */
+    public function negativeMessage();
+}

--- a/test/integration/AssertThrowsTest.php
+++ b/test/integration/AssertThrowsTest.php
@@ -32,6 +32,28 @@ class AssertThrowsTest extends IntegrationTestCase
         Assert::assertThat($matcher, true, 'this should throw');
     }
 
+    public function testAssertCallbackThrowsWhenUserDefinedCallbackReturnsFalse()
+    {
+        Assert::assertCallback(function () {
+            return false;
+        }, 'ignored');
+    }
+
+    public function testAssertCallbackThrowsWhenWrappedInLogicalNotAndReturningTrue()
+    {
+        // have to call this again here to get the message
+        $this->setExpectedException(
+            'Counterpart\\Exception\\AssertionFailed',
+            'does not match a user defined callback'
+        );
+
+        $matcher = Matchers::logicalNot(Matchers::callback(function () {
+            return true;
+        }));
+
+        Assert::assertThat($matcher, 'ignored');
+    }
+
     public function testAssertContainsThrowsWhenArrayDoesNotContainExpected()
     {
         Assert::assertContains(123, [234, 455], 'this should throw');

--- a/test/integration/AssertThrowsTest.php
+++ b/test/integration/AssertThrowsTest.php
@@ -39,21 +39,6 @@ class AssertThrowsTest extends IntegrationTestCase
         }, 'ignored');
     }
 
-    public function testAssertCallbackThrowsWhenWrappedInLogicalNotAndReturningTrue()
-    {
-        // have to call this again here to get the message
-        $this->setExpectedException(
-            'Counterpart\\Exception\\AssertionFailed',
-            'does not match a user defined callback'
-        );
-
-        $matcher = Matchers::logicalNot(Matchers::callback(function () {
-            return true;
-        }));
-
-        Assert::assertThat($matcher, 'ignored');
-    }
-
     public function testAssertContainsThrowsWhenArrayDoesNotContainExpected()
     {
         Assert::assertContains(123, [234, 455], 'this should throw');

--- a/test/integration/NegativeThrowsTest.php
+++ b/test/integration/NegativeThrowsTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2014 Christopher Davis <http://christopherdavis.me>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package     Counterpart
+ * @copyright   2014 Christopher Davis <http://christopherdavis.me>
+ * @license     http://opensource.org/licenses/apache-2.0 Apache-2.0
+ */
+
+namespace Counterpart;
+
+/**
+ * Checks all the implementations of `Negative` to make sure that, when wrapped
+ * in a `LogicalNot` they use `negativeMessage` to generate the assertion error.
+ */
+class NegativeThrowsTest extends IntegrationTestCase
+{
+    public static function negatives()
+    {
+        return [
+            'Callback'  => [Matchers::callback(function () { return true; }), 'ignored'],
+            'StringContains' => [Matchers::stringContains('here'), 'here'],
+            'MatchesRegex' => [Matchers::matchesRegex('/.*/'), 'ignored'],
+            'HasProperty' => [Matchers::hasProperty('prop'), (object)['prop' => true]],
+            'HasKey' => [Matchers::hasKey('k'), ['k' => true]],
+            'Contains' => [Matchers::contains('one'), ['one']],
+            'Anything' => [Matchers::anything(), ''],
+        ];
+    }
+
+    /**
+     * @dataProvider negatives
+     */
+    public function testLogicalNotCausesAnAssertionMessageWithNegativeDescription(Matcher $matcher, $value)
+    {
+        $this->setExpectedException(
+            'Counterpart\\Exception\\AssertionFailed',
+            $matcher->negativeMessage()
+        );
+
+        $matcher = Matchers::logicalNot($matcher);
+        Assert::assertThat($matcher, $value);
+    }
+}

--- a/test/unit/Matcher/LogicalNotTest.php
+++ b/test/unit/Matcher/LogicalNotTest.php
@@ -42,4 +42,40 @@ class LogicalNotTest extends LogicalCombinationTestCase
         $not = new LogicalNot($matcher);
         $this->assertEquals('is not something', (string)$not);
     }
+
+    public function testToStringCallsNegativeMessageWhenANegativeInterfaceIsFound()
+    {
+        $msg = 'does not match';
+        $matcher = new _NegMatcherStub($msg);
+
+        $not = new LogicalNot($matcher);
+        $this->assertEquals($msg, (string)$not);
+    }
 }
+
+// can't seem to get PHPUnit to stub multple interfaces
+class _NegMatcherStub implements \Counterpart\Matcher, \Counterpart\Negative
+{
+    private $msg;
+
+    public function __construct($msg)
+    {
+        $this->msg = $msg;
+    }
+
+    public function negativeMessage()
+    {
+        return $this->msg;
+    }
+
+    public function matches($actual)
+    {
+        return true;
+    }
+
+    public function __toString()
+    {
+        return 'always matches';
+    }
+}
+


### PR DESCRIPTION
Introduces the new interface `Counterpart\Negative` that, when used, will be check for with the `LogicalNot` matcher to give better error messages.

The `Negative` interface is also used in some appropriate places in the core matchers as well.
