### PR TITLE
Describing Matchers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "counterpart/counterpart"
     , "description": "A set of generic matchers -- for seeing if one value matches another"
+    , "type": "library"
     , "tags": ["testing", "assert", "matcher"]
     , "license": "Apache-2.0"
     , "authors": [
@@ -13,9 +14,10 @@
     , "require": {
         "php": ">=5.4"
         , "sebastian/exporter": "~1.0"
+        , "sebastian/diff": "~1.1"
     }
     , "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.1"
     }
     , "autoload": {
         "psr-4": {
@@ -25,5 +27,4 @@
             "src/utilities.php"
         ]
     }
-    , "minimum-stability": "dev"
 }

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -26,12 +26,21 @@ final class Assert
     public static function assertThat(Matcher $matcher, $actual, $message='')
     {
         if (!$matcher->matches($actual)) {
-            throw new Exception\AssertionFailed(sprintf(
+            $message = sprintf(
                 'Failed asserting that %s %s%s',
                 prettify($actual),
                 (string)$matcher,
-                $message ? "\n\t{$message}" : ''
-            ));
+                $message ? "\n{$message}" : ''
+            );
+
+            if ($matcher instanceof Describer) {
+                $desc = $matcher->describeMismatch($actual);
+                if (Describer::DECLINE_DESCRIPTION !== $desc) {
+                    $message .= "\n{$desc}";
+                }
+            }
+
+            throw new Exception\AssertionFailed($message);
         }
     }
 

--- a/src/Describer.php
+++ b/src/Describer.php
@@ -30,12 +30,15 @@ namespace Counterpart;
  */
 interface Describer
 {
+    // describeMismatch may decline to build a description by returning this
+    const DECLINE_DESCRIPTION = false;
+
     /**
      * Describe how $actual doesn't match the expected.
      *
      * @since   1.2
      * @param   string $actual
-     * @return  string
+     * @return  string|DECLINE_DESCRIPTION
      */
     public function describeMismatch($actual);
 }

--- a/src/Describer.php
+++ b/src/Describer.php
@@ -22,13 +22,13 @@
 namespace Counterpart;
 
 /**
- * Matchers that implement `SelfDescribing` can give more information about the
+ * Matchers that implement `Describer` can give more information about the
  * differences between the expected and actual value. This might mean diffs or
  * some other form of extract information.
  *
  * @since   1.3
  */
-interface SelfDescribing
+interface Describer
 {
     /**
      * Describe how $actual doesn't match the expected.

--- a/src/Matcher/IsType.php
+++ b/src/Matcher/IsType.php
@@ -31,6 +31,8 @@ use Counterpart\Exception\InvalidArgumentException;
  */
 class IsType implements Matcher
 {
+    use TypeTrait;
+
     /**
      * the type to check against.
      *
@@ -69,7 +71,11 @@ class IsType implements Matcher
      */
     public function __toString()
     {
-        $prefix = in_array($this->type[0], ['a', 'i', 'o', 'u', 'e']) ? 'an' : 'a';
-        return "is {$prefix} {$this->type}";
+        $art = $this->typeArticle($this->type);
+        return sprintf(
+            'is %s%s',
+            $art ? "{$art} " : '',
+            $this->type
+        );
     }
 }

--- a/src/Matcher/PhptFormat.php
+++ b/src/Matcher/PhptFormat.php
@@ -22,6 +22,7 @@
 namespace Counterpart\Matcher;
 
 use Counterpart\Matcher;
+use Counterpart\Describer;
 use Counterpart\Exception\InvalidArgumentException;
 
 /**
@@ -67,7 +68,7 @@ use Counterpart\Exception\InvalidArgumentException;
  *
  * @since   1.2
  */
-class PhptFormat implements Matcher
+class PhptFormat implements Matcher, Describer
 {
     private $format;
     private $regex = null;
@@ -111,6 +112,18 @@ class PhptFormat implements Matcher
     public function __toString()
     {
         return "is a string matching the phpt format {$this->format}";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function describeMismatch($actual)
+    {
+        if (!$this->isStringy($actual)) {
+            return 'actual value was not a string';
+        }
+
+        return \Counterpart\diff($this->format, (string)$actual);
     }
 
     private function isStringy($value)

--- a/src/Matcher/TypeTrait.php
+++ b/src/Matcher/TypeTrait.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2014 Christopher Davis <http://christopherdavis.me>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package     Counterpart\Test
+ * @copyright   2014 Christopher Davis <http://christopherdavis.me>
+ * @license     http://opensource.org/licenses/apache-2.0 Apache-2.0
+ */
+
+namespace Counterpart\Matcher;
+
+/**
+ * Provides some utilities for dealing with internal types.
+ *
+ * @since   1.3
+ */
+trait TypeTrait
+{
+    /**
+     * Get the appropriate article prefix for a type. (a or an)
+     *
+     * @since   1.3
+     * @param   $typeName
+     * @return  string|null Null if the type requires no prefix (ala numeric)
+     */
+    public function typeArticle($type)
+    {
+        if ('numeric' === $type) {
+            return null;
+        }
+
+        return in_array($type[0], ['a', 'i', 'o', 'u', 'e']) ? 'an' : 'a';
+    }
+}

--- a/src/utilities.php
+++ b/src/utilities.php
@@ -22,6 +22,7 @@
 namespace Counterpart;
 
 use SebastianBergmann\Exporter\Exporter;
+use SebastianBergmann\Diff\Differ;
 
 /**
  * Export a variable to a pretty string representation.
@@ -40,4 +41,22 @@ function prettify($var)
     }
 
     return $exporter->export($var);
+}
+
+/**
+ * Diff two strings and return their result.
+ *
+ * @since   1.3
+ * @param   string $expected
+ * @param   string $actual
+ * @return  string The generated diff
+ */
+function diff($expected, $actual)
+{
+    static $differ = null;
+    if (null === $differ) {
+        $differ = new Differ('--- Expected'.PHP_EOL.'+++ Actual'.PHP_EOL);
+    }
+
+    return trim($differ->diff($expected, $actual));
 }

--- a/test/integration/UtilitiesTest.php
+++ b/test/integration/UtilitiesTest.php
@@ -41,4 +41,13 @@ class UtilitiesTest extends IntegrationTestCase
         $obj->prop->three = "three";
         $this->assertInternalType('string', prettify($obj));
     }
+
+    public function testDiffReturnsStringWithExpectedHeaderAndDiff()
+    {
+        $diff = diff('one', 'two');
+
+        $this->assertInternalType('string', $diff);
+        $this->assertContains('--- Expected', $diff);
+        $this->assertContains('+++ Actual', $diff);
+    }
 }

--- a/test/unit/AssertTest.php
+++ b/test/unit/AssertTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright 2014 Christopher Davis <http://christopherdavis.me>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package     Counterpart\Test
+ * @copyright   2014 Christopher Davis <http://christopherdavis.me>
+ * @license     http://opensource.org/licenses/apache-2.0 Apache-2.0
+ */
+
+namespace Counterpart;
+
+/**
+ * Tests `Assert::assertThat` to verify its behavior
+ */
+class AssertTest extends TestCase
+{
+    public function testAssertThatWithMatchDoesNothing()
+    {
+        $matcher = $this->matcherReturning(true);
+
+        Assert::assertThat($matcher, 'ignored');
+    }
+
+    public function testAssertThatWithMisMatchThrows()
+    {
+        $this->expectAssertionFailure();
+        $matcher = $this->matcherReturning(false);
+
+        Assert::assertThat($matcher, 'ignored');
+    }
+
+    public function testAssertThatWithDescriberAddsAdditionaMessage()
+    {
+        $desc = 'additional stuff';
+        $matcher = new _StubAssertMatcher(false, $desc);
+        $this->expectAssertionFailure($desc);
+
+        Assert::assertThat($matcher, 'ignored');
+    }
+
+    private function matcherReturning($bool, $msg='')
+    {
+        $m = $this->getMock('Counterpart\\Matcher');
+        $m->expects($this->atLeastOnce())
+            ->method('matches')
+            ->willReturn($bool);
+        $m->expects($this->any())
+            ->method('__toString')
+            ->willReturn($msg);
+
+        return $m;
+    }
+
+    private function expectAssertionFailure($msg='')
+    {
+        $this->setExpectedException(
+            'Counterpart\\Exception\\AssertionFailed',
+            $msg
+        );
+    }
+}
+
+class _StubAssertMatcher implements Matcher, Describer
+{
+    private $matchVal;
+    private $descVal;
+
+    public function __construct($matchVal, $descVal)
+    {
+        $this->matchVal = $matchVal;
+        $this->descVal = $descVal;
+    }
+
+    public function matches($actual)
+    {
+        return $this->matchVal;
+    }
+
+    public function __toString()
+    {
+        return '';
+    }
+
+    public function describeMismatch($actual)
+    {
+        return $this->descVal;
+    }
+}

--- a/test/unit/Matcher/IsEqualTest.php
+++ b/test/unit/Matcher/IsEqualTest.php
@@ -109,4 +109,33 @@ class IsEqualTest extends TestCase
     {
         $this->assertFalse((new IsEqual($expected, true))->matches($actual));
     }
+
+    public function testDescribeMismatchWithDifferingTypesTellsUser()
+    {
+        $eq = new IsEqual('a string', true);
+
+        $this->assertContains('not a string', $eq->describeMismatch(['an', 'array']));
+    }
+
+    public function testBooleanTypeWithDescribeMismatchStillTellsUserAboutTypeDifference()
+    {
+        $eq = new IsEqual(false);
+        $this->assertContains('not a bool', $eq->describeMismatch(['an', 'array']));
+    }
+
+    public function testDescribeMismatchWithTypeStringsGeneratesADiff()
+    {
+        $eq = new IsEqual('one');
+
+        $diff = $eq->describeMismatch('two');
+        $this->assertContains('--- Expected', $diff);
+        $this->assertContains('+++ Actual', $diff);
+    }
+
+    public function testDescribeMismatchWithMatchingTypesAndNoStringsDeclinesDescription()
+    {
+        $eq = new IsEqual(false);
+
+        $this->assertEquals(\Counterpart\Describer::DECLINE_DESCRIPTION, $eq->describeMismatch(true));
+    }
 }

--- a/test/unit/Matcher/PhptFormatTest.php
+++ b/test/unit/Matcher/PhptFormatTest.php
@@ -25,6 +25,8 @@ use Counterpart\TestCase;
 
 class PhptFormatTest extends TestCase
 {
+    const FORMAT = "here %s\nversion %s";
+
     /**
      * @expectedException Counterpart\Exception\CounterpartException
      */
@@ -78,5 +80,22 @@ class PhptFormatTest extends TestCase
         $m = new PhptFormat($format);
 
         $this->assertTrue($m->matches($shouldMatch));
+    }
+
+    public function testDescribeMismatchWithANonStringTellsUsAboutIt()
+    {
+        $matcher = new PhptFormat(self::FORMAT);
+        $desc = $matcher->describeMismatch(false);
+
+        $this->assertContains('not a string', $desc);
+    }
+
+    public function testDescribeMismatchReturnsDiffWhenGivenAString()
+    {
+        $matcher = new PhptFormat(self::FORMAT);
+        $desc = $matcher->describeMismatch("here 123\nversion 234");
+
+        $this->assertContains('--- Expected', $desc);
+        $this->assertContains('+++ Actual', $desc);
     }
 }

--- a/test/unit/Matcher/TypeTraitTest.php
+++ b/test/unit/Matcher/TypeTraitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2014 Christopher Davis <http://christopherdavis.me>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package     Counterpart\Test
+ * @copyright   2014 Christopher Davis <http://christopherdavis.me>
+ * @license     http://opensource.org/licenses/apache-2.0 Apache-2.0
+ */
+
+namespace Counterpart\Matcher;
+
+use Counterpart\TestCase;
+
+class TypeTraitTest extends TestCase
+{
+    private $typeTrait;
+
+    public function testTypeArticleReturnsNullWithNumeric()
+    {
+        $this->assertNull($this->typeTrait->typeArticle('numeric'));
+    }
+
+    public function testTypeArticleReturnsAnForTypesThatStartWithVowels()
+    {
+        $this->assertEquals('an', $this->typeTrait->typeArticle('array'));
+    }
+
+    public function testTypeArticleReturnsAForTypesThatStartWithConsonants()
+    {
+        $this->assertEquals('a', $this->typeTrait->typeArticle('string'));
+    }
+
+    protected function setUp()
+    {
+        $this->typeTrait = $this->getObjectForTrait('Counterpart\\Matcher\\TypeTrait');
+    }
+}


### PR DESCRIPTION
Introduce a new interface `Describer` that, when implemented, allows a matcher to add some additional information (like diffs!) to assertion failure messages.
